### PR TITLE
Update snakemake tutorial format

### DIFF
--- a/docs/Bioinformatics-Tutorials/Snakemake/index.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/index.md
@@ -42,18 +42,18 @@ Est. Time | Lesson name | Description
 
     Videos: 
 
-        - Part 1: [Introducing the Snakefile and Snakemake](./snakemake_2.md)
+    - Part 1: [Introducing the Snakefile and Snakemake](./snakemake_2.md)
 
-        - Part 2: [Continue decorating the Snakefile](./snakemake_4.md)
+    - Part 2: [Continue decorating the Snakefile](./snakemake_4.md)
 
-        - Part 3: [More decorating and running through the entire Snakemake workflow](./snakemake_4.md)
+    - Part 3: [More decorating and running through the entire Snakemake workflow](./snakemake_4.md)
 
     [Example Snakefile](./example_snakefile.md)
 
     Cheatsheets:
 
-        - [bash and nano](../../Resources/bash_cheatsheet.md)
+    - [bash and nano](../../Resources/bash_cheatsheet.md)
     
-        - [conda](../../Resources/conda_cheatsheet.md)
+    - [conda](../../Resources/conda_cheatsheet.md)
   
-        - [Snakemake](../../Resources/snakemake_cheatsheet.md)
+    - [Snakemake](../../Resources/snakemake_cheatsheet.md)

--- a/docs/Bioinformatics-Tutorials/Snakemake/index.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/index.md
@@ -14,7 +14,7 @@ These materials were was adapted from the Data Intensive Biology lab course mate
 Est. Time | Lesson name | Description
 --- | --- | ---
 5 mins | [Introduction](./snakemake_0.md) | What is a workflow? <br />What is Snakemake?
-30 mins | [Setup](./snakemake_1.md) | Set up tutorial computing environment
+30 mins | [Set Up](./snakemake_1.md) | Set up tutorial computing environment
 30 mins | [The Snakefile](./snakemake_2.md) | What is the Snakefile? <br />What are Snakemake rules?
 45 mins | [Decorating the Snakefile](./snakemake_3.md) | How do the rules link together?
 30 mins | [Continue Decorating](./snakemake_4.md) | More on rule linking

--- a/docs/Bioinformatics-Tutorials/Snakemake/index.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/index.md
@@ -9,6 +9,17 @@ Workflow management systems help to automate analyses and make them easier to ma
 
 This may not be the variant calling workflow you would necessarily use in practice, but it serves as a good example for teaching Snakemake. Many people do indeed use `samtools`, but for particularly big or complex genomes, guidelines provided by  [GATK](https://gatk.broadinstitute.org/hc/en-us) would serve best. Additionally, various parameters associated with mapping, visualization etc may require tuning.
 
+These materials were was adapted from the Data Intensive Biology lab course materials ([course materials](https://github.com/ngs-docs/2020-GGG298), [lab materials](https://github.com/ngs-docs/2020-GGG201b-lab)).
+
+Est. Time | Lesson name | Description
+--- | --- | ---
+5 mins | [Introduction](./snakemake_0.md) | What is a workflow? <br />What is Snakemake?
+30 mins | [Setup](./snakemake_1.md) | Set up tutorial computing environment
+30 mins | [The Snakefile](./snakemake_2.md) | What is the Snakefile? <br />What are Snakemake rules?
+45 mins | [Decorating the Snakefile](./snakemake_3.md) | How do the rules link together?
+30 mins | [Continue Decorating](./snakemake_4.md) | More on rule linking
+20 mins | [Run Through the Workflow](./snakemake_5.md) | Final Snakemake rule <br />What are the results?
+
 !!! note "Learning Objectives"
 
     The objectives of this tutorial are to:
@@ -20,38 +31,29 @@ This may not be the variant calling workflow you would necessarily use in practi
     - learn wildcard matching for Snakemake rules
     
     - understand why workflow systems can help you do your computing more easily
-    
-These materials were was adapted from the Data Intensive Biology lab course materials ([course materials](https://github.com/ngs-docs/2020-GGG298), [lab materials](https://github.com/ngs-docs/2020-GGG201b-lab)).
+
 
 !!! note "Prerequisites"
     
     This tutorial is written for a Unix or Linux compute environment (e.g., MacOS, Linux-based HPC, pre-configured binder). It assumes basic knowledge of navigating, editing files, and executing scripts from the command line. Some knowledge of Python is useful, but not required.    
 
-Est. Time | Lesson name | Description
---- | --- | ---
-5 mins | [Introduction](./snakemake_0.md) | What is a workflow? <br />What is Snakemake?
-30 mins | [Setup](./snakemake_1.md) | Set up tutorial computing environment
-30 mins | [The Snakefile](./snakemake_2.md) | What is the Snakefile? <br />What are Snakemake rules?
-45 mins | [Decorating the Snakefile](./snakemake_3.md) | How do the rules link together?
-30 mins | [Continue Decorating](./snakemake_4.md) | More on rule linking
-20 mins | [Run Through the Workflow](./snakemake_5.md) | Final Snakemake rule <br />What are the results?
 
-Tutorial resources:
+!!! note "Tutorial Resources"
 
-- Videos: 
+    Videos: 
 
-    - Part 1: [Introducing the Snakefile and Snakemake](./snakemake_2.md)
+        - Part 1: [Introducing the Snakefile and Snakemake](./snakemake_2.md)
 
-    - Part 2: [Continue decorating the Snakefile](./snakemake_4.md)
+        - Part 2: [Continue decorating the Snakefile](./snakemake_4.md)
 
-    - Part 3: [More decorating and running through the entire Snakemake workflow](./snakemake_4.md)
+        - Part 3: [More decorating and running through the entire Snakemake workflow](./snakemake_4.md)
 
-- [Example Snakefile](./example_snakefile.md)
+    [Example Snakefile](./example_snakefile.md)
 
-- Cheatsheets:
+    Cheatsheets:
 
-    - [bash and nano](../../Resources/bash_cheatsheet.md)
+        - [bash and nano](../../Resources/bash_cheatsheet.md)
     
-    - [conda](../../Resources/conda_cheatsheet.md)
+        - [conda](../../Resources/conda_cheatsheet.md)
   
-    - [Snakemake](../../Resources/snakemake_cheatsheet.md)
+        - [Snakemake](../../Resources/snakemake_cheatsheet.md)

--- a/docs/Bioinformatics-Tutorials/Snakemake/index.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/index.md
@@ -18,7 +18,7 @@ Est. Time | Lesson name | Description
 30 mins | [The Snakefile](./snakemake_2.md) | What is the Snakefile? <br />What are Snakemake rules?
 45 mins | [Decorating the Snakefile](./snakemake_3.md) | How do the rules link together?
 30 mins | [Continue Decorating](./snakemake_4.md) | More on rule linking
-20 mins | [Run Through the Workflow](./snakemake_5.md) | Final Snakemake rule <br />What are the results?
+20 mins | [Run the Whole Pipeline](./snakemake_5.md) | Final Snakemake rule <br />What are the results?
 
 !!! note "Learning Objectives"
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/index.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/index.md
@@ -7,7 +7,7 @@ title: Snakemake Overview
 
 Workflow management systems help to automate analyses and make them easier to maintain, reproduce, and share with others. In this tutorial, we will walk through the basic steps for creating a [variant calling](https://www.ebi.ac.uk/training-beta/online/courses/human-genetic-variation-introduction/variant-identification-and-analysis/) workflow with the Snakemake workflow management system.
 
-This may not be the variant calling workflow you would necessarily use in practice, but it serves as a good example for teaching Snakemake. Many people do indeed use `samtools`, but for particularly big or complex genomes, guidelines provided by  [GATK](https://gatk.broadinstitute.org/hc/en-us) would serve best. Additionally, various parameters associated with mapping, visualization etc may require tuning.
+This may not be the variant calling workflow you would necessarily use in practice, but it serves as a good example for teaching Snakemake. Many people do indeed use `samtools`, but for particularly big or complex genomes, guidelines provided by  [GATK](https://gatk.broadinstitute.org/hc/en-us) would serve best. Additionally, various parameters associated with mapping, visualization, etc. may require tuning.
 
 These materials were adapted from the Data Intensive Biology lab course materials ([course materials](https://github.com/ngs-docs/2020-GGG298), [lab materials](https://github.com/ngs-docs/2020-GGG201b-lab)).
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/index.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/index.md
@@ -9,7 +9,7 @@ Workflow management systems help to automate analyses and make them easier to ma
 
 This may not be the variant calling workflow you would necessarily use in practice, but it serves as a good example for teaching Snakemake. Many people do indeed use `samtools`, but for particularly big or complex genomes, guidelines provided by  [GATK](https://gatk.broadinstitute.org/hc/en-us) would serve best. Additionally, various parameters associated with mapping, visualization etc may require tuning.
 
-These materials were was adapted from the Data Intensive Biology lab course materials ([course materials](https://github.com/ngs-docs/2020-GGG298), [lab materials](https://github.com/ngs-docs/2020-GGG201b-lab)).
+These materials were adapted from the Data Intensive Biology lab course materials ([course materials](https://github.com/ngs-docs/2020-GGG298), [lab materials](https://github.com/ngs-docs/2020-GGG201b-lab)).
 
 Est. Time | Lesson name | Description
 --- | --- | ---
@@ -33,12 +33,12 @@ Est. Time | Lesson name | Description
     - understand why workflow systems can help you do your computing more easily
 
 
-!!! note "Prerequisites"
+=== "Prerequisites"
     
     This tutorial is written for a Unix or Linux compute environment (e.g., MacOS, Linux-based HPC, pre-configured binder). It assumes basic knowledge of navigating, editing files, and executing scripts from the command line. Some knowledge of Python is useful, but not required.    
 
 
-!!! note "Tutorial Resources"
+=== "Tutorial Resources"
 
     Videos: 
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_0.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_0.md
@@ -1,4 +1,4 @@
-# Snakemake Introduction
+# Introduction
 
 ## What is a workflow system and why use one?
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_1.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_1.md
@@ -104,9 +104,9 @@ You should have several software installed in your `snaketest` environment now. 
     Copyright (C) 2019 Genome Research Ltd.
     ```
 
-If you get an error, the software installation may have failed. You can check the software that is installed in your conda environment: `conda list`.
+If you get an error, the software installation may have failed. You can check the software that is installed in your conda environment: `conda list`
 
-To leave the conda environment, type: `conda deactivate`.
+To leave the conda environment, type: `conda deactivate`
 
 Later in the tutorial, we'll use `wget` to download data. Installing `wget` on MacOS can be achieved with `conda install`. This step will take a few minutes and the installation should be done in the `base` conda environment:
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_1.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_1.md
@@ -1,4 +1,4 @@
-# Set up
+# Set Up
 
 ## Choose computing environment
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_2.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_2.md
@@ -10,7 +10,7 @@ Part 1: Introducing the Snakefile and Snakemake
 
 <iframe id="kaltura_player" src="https://cdnapisec.kaltura.com/p/1770401/sp/177040100/embedIframeJs/uiconf_id/29032722/partner_id/1770401?iframeembed=true&playerId=kaltura_player&entry_id=1_t0putehi&flashvars[mediaProtocol]=rtmp&amp;flashvars[streamerType]=rtmp&amp;flashvars[streamerUrl]=rtmp://www.kaltura.com:1935&amp;flashvars[rtmpFlavors]=1&amp;flashvars[localizationCode]=en&amp;flashvars[leadWithHTML5]=true&amp;flashvars[sideBarContainer.plugin]=true&amp;flashvars[sideBarContainer.position]=left&amp;flashvars[sideBarContainer.clickToClose]=true&amp;flashvars[chapters.plugin]=true&amp;flashvars[chapters.layout]=vertical&amp;flashvars[chapters.thumbnailRotator]=false&amp;flashvars[streamSelector.plugin]=true&amp;flashvars[EmbedPlayer.SpinnerTarget]=videoHolder&amp;flashvars[dualScreen.plugin]=true&amp;flashvars[Kaltura.addCrossoriginToIframe]=true&amp;&wid=0_og159i3p" width="608" height="402" allowfullscreen webkitallowfullscreen mozAllowFullScreen allow="autoplay *; fullscreen *; encrypted-media *" sandbox="allow-forms allow-same-origin allow-scripts allow-top-navigation allow-pointer-lock allow-popups allow-modals allow-orientation-lock allow-popups-to-escape-sandbox allow-presentation allow-top-navigation-by-user-activation" frameborder="0" title="Kaltura Player"></iframe>
 
-### Editing the Snakefile
+### Step 1: Editing the Snakefile
 
 Make sure you're in the `(snaketest)` conda environment. The remainder of this tutorial will be in the `(snaketest)` environment.
 
@@ -46,7 +46,7 @@ There are several rules defined with commands to run, but we'll need to add a fe
 
 Ok, let's move on and take a look at the structure of the Snakefile rules.
 
-### Snakefile rules
+### Step 2: Looking at Snakefile rules
 
 Each step in a pipeline is defined by a rule in the Snakefile. The components of each rule are indented 4 spaces. The most basic structure of a rule is:
 
@@ -101,7 +101,7 @@ There are several rules in the Snakefile. Let's do a search for all the rules in
     rule make_vcf:
     ```
 
-## Snakemake & Snakefile
+## Step 3: Running Snakemake & the Snakefile
 
 Let's try running a Snakemake rule:
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_2.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_2.md
@@ -31,7 +31,7 @@ There are several rules defined with commands to run, but we'll need to add a fe
 
     2. on a new line, add a comment with `#`, e.g., `# This is my first edit!`
 
-    3. save the change by hitting `control` key and `o` key. `nano` will ask if you want to save the file as 'Snakefile'. We want to keep the same file name, so hit `return` key.
+    3. save the change by hitting `control` key and `o` key. `nano` will ask if you want to save the file as "Snakefile". We want to keep the same file name, so hit `return` key.
 
     4. exit `nano` by hitting `control` key and `x` key.
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_2.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_2.md
@@ -101,7 +101,7 @@ There are several rules in the Snakefile. Let's do a search for all the rules in
     rule make_vcf:
     ```
 
-## Step 3: Running Snakemake & the Snakefile
+### Step 3: Running Snakemake & the Snakefile
 
 Let's try running a Snakemake rule:
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_3.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_3.md
@@ -71,7 +71,7 @@ Try: Run the `download_data` rule twice.
 
 Delete the file: `rm SRR2584857_1.fastq.gz`. Now run the rule again.
 
-This time the shell command is executed! By explicitly including the `output` file in the rule, Snakemake was smart to know that the output file already exists and doesn't need to be re-created.
+This time the shell command is executed! By explicitly including the `output` file in the rule, Snakemake was smart enough to know that the output file already exists and doesn't need to be re-created.
 
 ### Step 5: Adding input files
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_3.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_3.md
@@ -32,14 +32,15 @@ By defining the inputs and outputs for each rule's command/commands, Snakemake c
 
 Here, Snakemake interprets the `input:` and `output:` sections as Python code, and the `shell:` section as the bash code that gets run on the command line.
 
-### Add input and output files
+### Step 4: Adding output files
 
-Let's start with a clean slate. Delete any output files you created in the sections above, such that you only have the Snakefile in your directory: `rm <file name>`.
+Let's start with a clean slate. 
 
 !!! warning
-    Be careful with `rm` command - it deletes files forever!
 
-**Adding outputs:**
+    Be careful with `rm` command - it deletes files forever!
+    
+Delete any output files you created in the sections above, such that you only have the Snakefile in your directory: `rm <file name>`.
 
 The output of the `download_data` rule is `SRR2584857_1.fastq.gz`. Add this to the rule, note that the output file must be in quotes `""`:
 
@@ -72,9 +73,9 @@ Delete the file: `rm SRR2584857_1.fastq.gz`. Now run the rule again.
 
 This time the shell command is executed! By explicitly including the `output` file in the rule, Snakemake was smart to know that the output file already exists and doesn't need to be re-created.
 
-**Adding inputs:**
+### Step 5: Adding input files
 
-To the `download_genome` rule, add:
+To the `download_genome` rule, define the following output file:
 
 === "Snakemake rule"
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_3.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_3.md
@@ -2,7 +2,7 @@
 
 In the previous steps, the Snakemake rules were run individually. But what if we want to run all the commands at once? It gets tedious to run each command individually, and we can do that already without Snakemake!
 
-By defining the inputs and outputs for each rule's command/commands, Snakemake can figure out how the rules are linked together. The rule structure will now look something like this, where `input:`, `output:`, and `shell:` are Snakemake directives:
+By defining the inputs and outputs for each rule's command(s), Snakemake can figure out how the rules are linked together. The rule structure will now look something like this, where `input:`, `output:`, and `shell:` are Snakemake directives:
 
 === "Snakemake rule"
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_4.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_4.md
@@ -14,9 +14,12 @@ Part 3: More decorating and running through the entire Snakemake workflow
 
 <iframe id="kaltura_player" src="https://cdnapisec.kaltura.com/p/1770401/sp/177040100/embedIframeJs/uiconf_id/29032722/partner_id/1770401?iframeembed=true&playerId=kaltura_player&entry_id=1_q2n1e8ck&flashvars[mediaProtocol]=rtmp&amp;flashvars[streamerType]=rtmp&amp;flashvars[streamerUrl]=rtmp://www.kaltura.com:1935&amp;flashvars[rtmpFlavors]=1&amp;flashvars[localizationCode]=en&amp;flashvars[leadWithHTML5]=true&amp;flashvars[sideBarContainer.plugin]=true&amp;flashvars[sideBarContainer.position]=left&amp;flashvars[sideBarContainer.clickToClose]=true&amp;flashvars[chapters.plugin]=true&amp;flashvars[chapters.layout]=vertical&amp;flashvars[chapters.thumbnailRotator]=false&amp;flashvars[streamSelector.plugin]=true&amp;flashvars[EmbedPlayer.SpinnerTarget]=videoHolder&amp;flashvars[dualScreen.plugin]=true&amp;flashvars[Kaltura.addCrossoriginToIframe]=true&amp;&wid=0_ac2qdn2j" width="608" height="402" allowfullscreen webkitallowfullscreen mozAllowFullScreen allow="autoplay *; fullscreen *; encrypted-media *" sandbox="allow-forms allow-same-origin allow-scripts allow-top-navigation allow-pointer-lock allow-popups allow-modals allow-orientation-lock allow-popups-to-escape-sandbox allow-presentation allow-top-navigation-by-user-activation" frameborder="0" title="Kaltura Player"></iframe>
 
+### Step 6: Decorating the remaining rules
+
 Run the rules one at a time to figure out what the output files are. Check the file time stamps (`ls -lht`) to track more recent output files. The inputs are specified in the shell command section.
 
 !!! Tip
+
     You can do a dry run of the rule with `snakemake -n <rule name>` to check how Snakemake is interpreting the rule input(s), output(s), and shell command(s), without actually running the command(s) or creating any output(s).
 
 Sometimes a command may require multiple input files but only explicitly state one in the command (the software assumes that if a certain file exists the other required files must exist). To avoid potential errors in rule dependencies, we will define all inputs in the rule's `input:` section.
@@ -39,7 +42,7 @@ In this workflow, the rule `map_reads` is a good example of such a behavior. `bw
     
 Follow along with the video tutorials to fill in the `input` and `output` sections for the remaining rules. For help, refer to the complete [Snakefile](./example_snakefile.md) for this tutorial, but note that there are many ways to concisely enter the input and output files and this is just one version!
 
-### Running lots of rules all at once
+### Step 7: Running lots of rules all at once
 
 Once you've fixed the rules `index_genome_bwa` and `map_reads`, you should be able to run everything up to the rule `index_genome_samtools` by running:
 
@@ -49,14 +52,14 @@ snakemake -p index_genome_samtools
 
 This also serves as a good way to check that you have all the correct input/output information. You'll have files left over if you forgot to put them in output.
 
-### Re-running rules
+### Step 8: Re-running rules
 
 Snakemake also has the option to delete all the inputs/outputs for a particular rule (including preceding rules), shown here by running the `index_genome_samtools` rule:
 ```
 snakemake --delete-all-output index_genome_samtools
 ```
 
-### Using filenames instead of rule names
+### Step 9: Using filenames instead of rule names
 
 You don't actually need to use the rule names *(this will be important later on!)*. Instead of rule names, you can specify the required output file in Snakemake which will trigger execution of all the upstream linked rules necessary to produce the file. So, the command below will also work to run the rule `map_reads`, and you don't have to remember the rule name (which can be arbitrary).
 
@@ -64,7 +67,7 @@ You don't actually need to use the rule names *(this will be important later on!
 snakemake -p SRR2584857.sam
 ```
 
-### Some python shortcuts
+### Step 10: Exploring rule decoration shortcuts
 
 There are several ways to more efficiently and cleanly specify inputs/outputs in the Snakefile. Here are some shortcuts:
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_5.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_5.md
@@ -1,5 +1,7 @@
 # Run the whole pipeline!
 
+### Step 11: Running the pipeline
+
 Once you've decorated the entire Snakefile, you should be able to run through the whole workflow using either the rule name:
 
 ```
@@ -30,7 +32,7 @@ snakemake -p all
 
 This rule runs through the entire workflow with a single command! This is much better than running each command one by one!
 
-## Looking at VCF files
+### Step 12: Looking at VCF files
 
 Finally, let's look at the output!
 
@@ -48,7 +50,7 @@ samtools tview -p ecoli:4202391 SRR2584857.sorted.bam ecoli-rel606.fa
     - Exit help menu by hitting `q` key
     - Go to a specific position location in the alignment by hitting `/` key.
 
-## Wrapping up
+## Conclusion
 
 Exit `(snaketest)` conda environment to return to `(base)` environment:
 

--- a/docs/Bioinformatics-Tutorials/Snakemake/snakemake_5.md
+++ b/docs/Bioinformatics-Tutorials/Snakemake/snakemake_5.md
@@ -58,6 +58,13 @@ Exit `(snaketest)` conda environment to return to `(base)` environment:
 conda deactivate
 ```
 
+Hopefully, you have now:
+
+- learned how to write basic workflows with Snakemake rules
+- learned variable substitution for Snakemake rules
+- learned wildcard matching for Snakemake rules
+- understood why workflow systems can help you do your computing more easily!
+
 !!! note "Key Points"
 
     - Snakefile defines a Snakemake workflow
@@ -68,9 +75,3 @@ conda deactivate
     - the rules are connected by matching filenames
     - tabs are important syntax feature in Snakemake
     
-Hopefully, you have now:
-
-- learned how to write basic workflows with Snakemake rules
-- learned variable substitution for Snakemake rules
-- learned wildcard matching for Snakemake rules
-- understood why workflow systems can help you do your computing more easily!

--- a/docs/General-Tutorials/index.md
+++ b/docs/General-Tutorials/index.md
@@ -23,5 +23,5 @@ Web Development:
 
 Conda:
 
-  - [Set up computing environment with conda on MacOS](install_conda_tutorial.md)
+  - [Set up Conda computing environment](install_conda_tutorial.md)
   


### PR DESCRIPTION
## PR type

- [ ] New tutorial
- [ ] Fixes to tutorials only on latest
- [ ] Fixes to tutorials on stable and latest
- [ ] Feature enhancement
- [x] Tutorial formatting
- [ ] Website formatting
- [ ] Other

## PR Checklist

- [x] Release label added
- [x] PR category label added
- [x] PR mergeable
- [x] Clean build logs
- [x] Linked related issues

## PR Description
we made some changes to the overall tutorial section layout. editing snakemake tutorial to update format + demo the new style guidelines

preview: https://cfde-training-and-engagement--197.com.readthedocs.build/en/197/Bioinformatics-Tutorials/Snakemake/

## Review format
i think this follows the style guide ;) let me know if you find format mistakes, edit directly or comment

## Timeline
before Oct 2020 release
