### PR TITLE
add matomo analytics script to training site

### DIFF
--- a/docs/templates/main.html
+++ b/docs/templates/main.html
@@ -1,6 +1,21 @@
 {% extends "base.html" %}
 {% block analytics %}
- 
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://nihcfde.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
 {% endblock %}
 
 {% block disqus %}


### PR DESCRIPTION
## PR Checklist

- [x] Release label added
- [x] PR category label added
- [x] PR mergeable
- [x] Clean build logs
- [x] Linked related issues
- [NA] Colorblindness test https://www.toptal.com/designers/colorfilter/

## PR Description
This adds the matomo analytics script which we are hoping to make official ASAP
https://github.com/dib-lab/cfde/issues/162

**Preview link**
https://training.nih-cfde.org/en/analytics/

## Review format
if the script doesn't break the website

## Timeline
would like to get this into the dec-2020 release or it might have to go in off schedule
