### PR TITLE
website tutorial template + cfde portal overview pg fixes

### DIFF
--- a/docs/Bioinformatics-Skills/CFDE-Portal/.pages
+++ b/docs/Bioinformatics-Skills/CFDE-Portal/.pages
@@ -1,3 +1,4 @@
 nav:
+ - index.md
  - Use Case 1: Blood-Cancer
  - Use Case 2: Movement-Related-Disorders

--- a/docs/Bioinformatics-Skills/CFDE-Portal/index.md
+++ b/docs/Bioinformatics-Skills/CFDE-Portal/index.md
@@ -1,5 +1,8 @@
 ---
 layout: page
+title: CFDE Portal Overview
+---
+
 
 **CFDE Portal Use Cases**
 

--- a/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
+++ b/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
@@ -18,7 +18,7 @@ Time | Section | About
 
 === "Resources"
 
-    - [Tutorial template markdown doc](./tutorial_template_docs/TutorialTemplate.md)
+    - [Get started with new tutorials using the tutorial template markdown doc](https://github.com/nih-cfde/training-and-engagement/blob/dev/docs/CFDE-Internal-Training/Website-Style-Guide/tutorial_template_docs/TutorialTemplate.md)
     - [Powerpoint slide template](https://drive.google.com/drive/u/0/folders/14dOaf7-G4k7rCw5mL2Q5jdRWXrO0Y5i-)
 
 

--- a/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
+++ b/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
@@ -14,7 +14,7 @@ Time | Section | About
 
 === "Prerequisites"
 
-    To contribute to the CFDE's website, you must be onboarded to the CFDE. Contact us for help if you're interested in contributing training materials!
+    To contribute to the CFDE's website, you must be onboarded to the CFDE. [Contact us](training@cfde.atlassian.net) for help if you're interested in contributing training materials!
 
 === "Resources"
 

--- a/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
+++ b/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
@@ -14,7 +14,7 @@ Time | Section | About
 
 === "Prerequisites"
 
-    To contribute to the CFDE's website, you must be onboarded to the CFDE. [Contact us](mailto:training@cfde.atlassian.net) for help if you're interested in contributing training materials!
+    To contribute to the CFDE's website, you must be onboarded to the CFDE. Contact us at <training@cfde.atlassian.net> for help if you're interested in contributing training materials!
 
 === "Resources"
 

--- a/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
+++ b/docs/CFDE-Internal-Training/Website-Style-Guide/0index.md
@@ -14,7 +14,7 @@ Time | Section | About
 
 === "Prerequisites"
 
-    To contribute to the CFDE's website, you must be onboarded to the CFDE. [Contact us](training@cfde.atlassian.net) for help if you're interested in contributing training materials!
+    To contribute to the CFDE's website, you must be onboarded to the CFDE. [Contact us](mailto:training@cfde.atlassian.net) for help if you're interested in contributing training materials!
 
 === "Resources"
 

--- a/docs/CFDE-Internal-Training/Website-Style-Guide/3TutorialComponents.md
+++ b/docs/CFDE-Internal-Training/Website-Style-Guide/3TutorialComponents.md
@@ -28,7 +28,11 @@ Tutorials should consist primarily of original content. If lesson material is ad
 
 ## Tutorial structure
 
-All tutorials should begin with landing page information. For longer tutorials that are split over multiple pages, start the tutorial steps on a new page (more details below). See the [tutorial template](./tutorial_template_docs/TutorialTemplate.md) for a page outline. For one-page tutorials, the landing "page" information may all be on the same page as the tutorial steps.
+All tutorials should begin with landing page information. For longer tutorials that are split over multiple pages, start the tutorial steps on a new page (more details below). For one-page tutorials, the landing "page" information may all be on the same page as the tutorial steps.
+
+!!! tip
+
+    See the [markdown tutorial template](https://github.com/nih-cfde/training-and-engagement/blob/dev/docs/CFDE-Internal-Training/Website-Style-Guide/tutorial_template_docs/TutorialTemplate.md) for a page outline. You can copy/paste the markdown to start new tutorials.
 
 ### Tutorial landing page components
 

--- a/docs/CFDE-Internal-Training/Website-Style-Guide/tutorial_template_docs/TutorialTemplate.md
+++ b/docs/CFDE-Internal-Training/Website-Style-Guide/tutorial_template_docs/TutorialTemplate.md
@@ -3,7 +3,7 @@ layout: page
 title: Overview
 ---
 
-Note, overview/landing pages should have the yaml file header, e.g.,:
+Note, overview/landing pages should start with the yaml file header, e.g.,:
 ```
 ---
 layout: page


### PR DESCRIPTION
## PR Checklist

- [x] Release label added
- [x] PR category label added
- [x] PR mergeable
- [x] Clean build logs
- [ ] Linked related issues - n/a
- [ ] Colorblindness test https://www.toptal.com/designers/colorfilter/ -n/a

## PR Description
- clarify what tutorial template is for from the website style guide.
- add back index/overview page for cfde portal use cases tutorial 

**Preview link**
https://cfde-training-and-engagement--304.com.readthedocs.build/en/304/CFDE-Internal-Training/Website-Style-Guide/0index/

## Review format
direct edits!


## Timeline
Feb 2021