### PR TITLE
update cfdebot tutorial and fix conda resources

### DIFF
--- a/docs/Bioinformatics-Skills/Snakemake/snakemake_0.md
+++ b/docs/Bioinformatics-Skills/Snakemake/snakemake_0.md
@@ -10,6 +10,6 @@ Workflow systems help you automate and manage the inputs, outputs, and commands 
 
 [Snakemake](https://snakemake.readthedocs.io/en/stable/) is a Python-based workflow system ([see 2012 publication](https://academic.oup.com/bioinformatics/article/28/19/2520/290322)). The name "Snakemake" comes from the fact that it's written in (and can be extended by) the Python programming language.
 
-Snakemake works by looking at a file, called a "Snakefile", that contains rules for creating output files. Generally, each rule is defined as a step in the workflow. Snakemake uses the rules and command line options to figure how the rules relate to each other so it can manage the workflow steps.
+Snakemake works by looking at a file, called a "Snakefile", that contains rules for creating output files. Generally, each rule is defined as a step in the workflow. Snakemake uses the rules and command line options to figure out how the rules relate to each other so it can manage the workflow steps.
 
 Let's get started!

--- a/docs/Bioinformatics-Skills/install_conda_tutorial.md
+++ b/docs/Bioinformatics-Skills/install_conda_tutorial.md
@@ -94,10 +94,8 @@ Check the version of your new conda installation:
 Conda uses channels to look for available software installations. These are some good channels to set up:
 
 ```
+conda config --add channels defaults
 conda config --add channels bioconda
-```
-
-```
 conda config --add channels conda-forge
 ```
 
@@ -109,7 +107,7 @@ There is always a `(base)` conda environment. You can then create new environmen
 conda create -n <name of env>
 ```
 
-This takes a few minutes (you'll see the message "Solving environment"). Conda will then ask you to confirm the location of the new environment. Type `y`.
+This takes a few minutes (you'll see the message "Solving environment"). Conda will then ask you to confirm the location of the new environment. Type ++y++.
 
 More options to customize the environment are documented under the help page for this command: `conda create -h`.
 
@@ -143,7 +141,7 @@ The basic command for installing packages is:
 conda install -y <software name>
 ```
 
-It will ask if you want to install dependencies. Type `y`. This command will show a list of the software installed in this environment:
+It will ask if you want to install dependencies. Type ++y++. This command will show a list of the software installed in this environment:
 
 ```
 conda list -n <conda env name>

--- a/docs/CFDE-Internal-Training/cfdebot_website_editing.md
+++ b/docs/CFDE-Internal-Training/cfdebot_website_editing.md
@@ -102,7 +102,7 @@ The bot will automatically create preview branches (`update-<repo>-preview`) if 
 If the website build checks all pass, the bot will then automatically merge:
 
 - `update-fair-preview` into `cookbookpreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/](https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/)
-- `update-c2m2-preview` into `c2m2preview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/)
+- `update-c2m2-preview` into `update-c2m2`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/)
 
 #### Step 5: Publishing your changes
 

--- a/docs/CFDE-Internal-Training/cfdebot_website_editing.md
+++ b/docs/CFDE-Internal-Training/cfdebot_website_editing.md
@@ -102,7 +102,7 @@ The bot will automatically create preview branches (`update-<repo>-preview`) if 
 If the website build checks all pass, the bot will then automatically merge:
 
 - `update-fair-preview` into `cookbookpreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/](https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/)
-- `update-c2m2-preview` into `specspreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2/)
+- `update-c2m2-preview` into `c2m2preview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/)
 
 #### Step 5: Publishing your changes
 

--- a/docs/CFDE-Internal-Training/cfdebot_website_editing.md
+++ b/docs/CFDE-Internal-Training/cfdebot_website_editing.md
@@ -102,7 +102,7 @@ The bot will automatically create preview branches (`update-<repo>-preview`) if 
 If the website build checks all pass, the bot will then automatically merge:
 
 - `update-fair-preview` into `cookbookpreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/](https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/)
-- `update-c2m2-preview` into `specspreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/C2M2/](https://cfde-published-documentation.readthedocs-hosted.com/en/C2M2/)
+- `update-c2m2-preview` into `specspreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2/)
 
 #### Step 5: Publishing your changes
 

--- a/docs/CFDE-Internal-Training/cfdebot_website_editing.md
+++ b/docs/CFDE-Internal-Training/cfdebot_website_editing.md
@@ -70,11 +70,11 @@ The website created by the `published-documentation` repo pulls some docs that a
 Follow the general steps above, with the following additional steps:
 
 - Push your changes to the `preview` branch first to check the rendered website.
-- If the changes look as you expected, make a PR of your branch to `dev` and tag the admin team (@ACharbonneau and @marisalim), who will check the changes and approve. Approved changes will periodically be promoted to the `stable` branch to be rendered on the public website.
+- If the changes look as you expected, make a PR of your branch to `dev` and tag the admin team (@ACharbonneau or @marisalim), who will check the changes and approve. Approved changes will periodically be promoted to the `stable` branch to be rendered on the public website.
 
 ### B) **To edit documents that are in the sub-module repos**
 
-The cfde-bot's process for checking changes to the sub-module repos (`the-fair-cookbook` and `specifications-and-documentation`) is slightly different:
+The cfde-bot's process for checking changes to the sub-module repos (`the-fair-cookbook` and `c2m2`) is slightly different:
 
 - The `published-documentation` cfde-bot checks hourly for changes to the sub-module repo's `master` branch. Thus, changes should be made directly in these repositories.
 
@@ -89,7 +89,7 @@ The cfde-bot's process for checking changes to the sub-module repos (`the-fair-c
 Reminder: you must be onboarded to the CFDE to edit these repositories:
 
 - `the-fair-cookbook` repo: [https://github.com/nih-cfde/the-fair-cookbook](https://github.com/nih-cfde/the-fair-cookbook)
-- `specifications-and-documentation` repo: [https://github.com/nih-cfde/specifications-and-documentation](https://github.com/nih-cfde/specifications-and-documentation)
+- `c2m2` repo: [https://github.com/nih-cfde/c2m2](https://github.com/nih-cfde/c2m2)
 
 #### Step 2: Make changes *directly* on the `master` branch
 
@@ -102,7 +102,7 @@ The bot will automatically create preview branches (`update-<repo>-preview`) if 
 If the website build checks all pass, the bot will then automatically merge:
 
 - `update-fair-preview` into `cookbookpreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/](https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/)
-- `update-specsdocs-preview` into `specspreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/specspreview/](https://cfde-published-documentation.readthedocs-hosted.com/en/specspreview/)
+- `update-c2m2-preview` into `c2m2preview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/)
 
 #### Step 5: Publishing your changes
 

--- a/docs/CFDE-Internal-Training/cfdebot_website_editing.md
+++ b/docs/CFDE-Internal-Training/cfdebot_website_editing.md
@@ -102,7 +102,7 @@ The bot will automatically create preview branches (`update-<repo>-preview`) if 
 If the website build checks all pass, the bot will then automatically merge:
 
 - `update-fair-preview` into `cookbookpreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/](https://cfde-published-documentation.readthedocs-hosted.com/en/cookbookpreview/)
-- `update-c2m2-preview` into `update-c2m2`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/](https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/)
+- `update-c2m2-preview` into `specspreview`, and will build a preview site for you to browse at: [https://cfde-published-documentation.readthedocs-hosted.com/en/C2M2/](https://cfde-published-documentation.readthedocs-hosted.com/en/C2M2/)
 
 #### Step 5: Publishing your changes
 

--- a/docs/Cheat-Sheets/conda_cheatsheet.md
+++ b/docs/Cheat-Sheets/conda_cheatsheet.md
@@ -1,12 +1,19 @@
 # Conda Command Cheat Sheet
 
+Commonly used conda commands:
+
 conda | Description
 --- | ---
-`conda create -n <conda env name>` | create a new conda environment. You can include other flags to customize the environment more.
-`conda activate <conda env name>` | activate conda environment
-`conda install -y <software name>` | install software in conda environment
-`conda deactivate` | deactivate conda environment
-`conda info --envs` | list conda environments, `*` will be next to the environment you are currently in
-`conda list -n <conda env name>` | list software installed in this conda environment. Or simply, `conda list`.
-`conda info` | information about your conda environment
-`conda env remove --name <conda env name>` | remove a conda environment
+`conda create -n <conda env name>` or `conda create -n <conda env name> <software name>` | Create a new conda environment. You can include other flags to customize the environment more and install software in the conda environment. For example, `conda create -n fastqc_env fastqc` will install the FastQC program into a conda environment called `fastqc_env`.
+`conda env create -n <conda env name> -f <yaml file>` | Create a new conda environment using specifications from a yaml file. For example, `conda env create -n test -f environment.yml`.
+`conda install -y <software name>` | Install software in conda environment
+`conda activate <conda env name>` | Activate conda environment
+`conda deactivate` | Deactivate conda environment
+`conda info --envs` or `conda env list` | Both commands list conda environments, `*` will be next to the environment you are currently in
+`conda list -n <conda env name>` | List software installed in this conda environment. Or simply, `conda list`.
+`conda info` | Information about your conda environment
+`conda search <software name>` | Search for available software versions
+`conda env remove --name <conda env name>` | Remove a conda environment
+
+
+Download the official [conda cheat sheet](https://docs.conda.io/projects/conda/en/latest/user-guide/cheatsheet.html) for more commands


### PR DESCRIPTION
## PR Checklist

- [x] Release label added
- [x] PR category label added
- [x] PR mergeable
- [x] Clean build logs
- [ ] Linked related issues - n/a
- [ ] Colorblindness test https://www.toptal.com/designers/colorfilter/ - n/a

## PR Description

the specs repo was renamed. editing the repo/branch names in the cfdebot tutorial to match.
- is this correct?
branch `update-c2m2` -> https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2preview/
branch `update-c2m2-preview` -> https://cfde-published-documentation.readthedocs-hosted.com/en/c2m2/

might need to still be fixed in the tutorial. --> fixed

minor format fix + clarifications for conda resources.


**Preview link**
https://cfde-training-and-engagement--325.com.readthedocs.build/en/325/CFDE-Internal-Training/cfdebot_website_editing/

## Review format
direct edits

## Timeline
Feb release
