### PR TITLE
Add analytics to header.html

### DIFF
--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -1,5 +1,27 @@
 {% extends "overrides/main.html" %}
 
+{% block analytics %}
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
+  _paq.push(["setDomains", ["*.training.nih-cfde.org"]]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://nihcfde.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '2']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="https://nihcfde.matomo.cloud/matomo.php?idsite=2&amp;rec=1" style="border:0;" alt="" /></p></noscript>
+<!-- End Matomo Code -->
+{% endblock %}
+
 {% block tabs %}
   {{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/overrides.min.css' | url }}">

--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -1,27 +1,5 @@
 {% extends "overrides/main.html" %}
 
-{% block analytics %}
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
-  _paq.push(["setDomains", ["*.training.nih-cfde.org"]]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://nihcfde.matomo.cloud/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '2']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="https://nihcfde.matomo.cloud/matomo.php?idsite=2&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-{% endblock %}
-
 {% block tabs %}
   {{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/overrides.min.css' | url }}">

--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -164,23 +164,4 @@
   </section>
 {% endblock %}
 
-{% block analytics %}
-  {{ super() }}
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="https://nihcfde.matomo.cloud/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '3']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
-{% endblock %}
-
 {% block content %}{% endblock %}

--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -163,5 +163,4 @@
     </div>
   </section>
 {% endblock %}
-
 {% block content %}{% endblock %}

--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -1,5 +1,25 @@
 {% extends "overrides/main.html" %}
 
+{% block header %}
+   {{ super() }}
+   <script type="text/javascript">
+     var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+     _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+     _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
+     _paq.push(['trackPageView']);
+     _paq.push(['enableLinkTracking']);
+    (function() {
+       var u="https://nihcfde.matomo.cloud/";
+       _paq.push(['setTrackerUrl', u+'matomo.php']);
+       _paq.push(['setSiteId', '2']);
+       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+   </script>
+<!-- End Matomo Code -->
+{% endblock %}
+
 {% block tabs %}
   {{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/overrides.min.css' | url }}">

--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -163,4 +163,24 @@
     </div>
   </section>
 {% endblock %}
+
+{% block analytics %}
+  {{ super() }}
+  <!-- Matomo -->
+  <script type="text/javascript">
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://nihcfde.matomo.cloud/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '3']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+{% endblock %}
+
 {% block content %}{% endblock %}

--- a/custom/overrides/home.html
+++ b/custom/overrides/home.html
@@ -1,25 +1,5 @@
 {% extends "overrides/main.html" %}
 
-{% block header %}
-   {{ super() }}
-   <script type="text/javascript">
-     var _paq = window._paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-     _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-     _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
-     _paq.push(['trackPageView']);
-     _paq.push(['enableLinkTracking']);
-    (function() {
-       var u="https://nihcfde.matomo.cloud/";
-       _paq.push(['setTrackerUrl', u+'matomo.php']);
-       _paq.push(['setSiteId', '2']);
-       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-   </script>
-<!-- End Matomo Code -->
-{% endblock %}
-
 {% block tabs %}
   {{ super() }}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/overrides.min.css' | url }}">

--- a/custom/overrides/main.html
+++ b/custom/overrides/main.html
@@ -31,5 +31,3 @@
   </div>
  </footer>
 {% endblock %}
-
-

--- a/custom/overrides/main.html
+++ b/custom/overrides/main.html
@@ -32,21 +32,22 @@
  </footer>
 {% endblock %}
 {% block analytics %}
-    {{ super() }}
-    <!-- Matomo -->
-    <script type="text/javascript">
-      var _paq = window._paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(['trackPageView']);
-      _paq.push(['enableLinkTracking']);
-      (function() {
-        var u="https://nihcfde.matomo.cloud/";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '3']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-      })();
-    </script>
+<!-- Matomo -->
+<script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://nihcfde.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '2']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
 <!-- End Matomo Code -->
 {% endblock %}
 

--- a/custom/overrides/main.html
+++ b/custom/overrides/main.html
@@ -31,25 +31,5 @@
   </div>
  </footer>
 {% endblock %}
-{% block analytics %}
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-  _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
-  _paq.push(["setDomains", ["*.training.nih-cfde.org"]]);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://nihcfde.matomo.cloud/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '2']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="https://nihcfde.matomo.cloud/matomo.php?idsite=2&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-{% endblock %}
+
 

--- a/custom/overrides/main.html
+++ b/custom/overrides/main.html
@@ -31,21 +31,4 @@
   </div>
  </footer>
 {% endblock %}
-{% block analytics %}
-  {{ super() }}
-  <!-- Matomo -->
-  <script type="text/javascript">
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="https://nihcfde.matomo.cloud/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '3']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
-{% endblock %}
+

--- a/custom/overrides/main.html
+++ b/custom/overrides/main.html
@@ -31,4 +31,22 @@
   </div>
  </footer>
 {% endblock %}
+{% block analytics %}
+    {{ super() }}
+    <!-- Matomo -->
+    <script type="text/javascript">
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://nihcfde.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '3']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+<!-- End Matomo Code -->
+{% endblock %}
 

--- a/custom/overrides/main.html
+++ b/custom/overrides/main.html
@@ -38,6 +38,7 @@
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
   _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
+  _paq.push(["setDomains", ["*.training.nih-cfde.org"]]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
@@ -48,6 +49,7 @@
     g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
+<noscript><p><img src="https://nihcfde.matomo.cloud/matomo.php?idsite=2&amp;rec=1" style="border:0;" alt="" /></p></noscript>
 <!-- End Matomo Code -->
 {% endblock %}
 

--- a/custom/partials/header.html
+++ b/custom/partials/header.html
@@ -6,6 +6,23 @@
   {% set site_url = site_url ~ "/index.html" %}
 {% endif %}
 <header class="md-header" data-md-component="header">
+<!-- Matomo Code -->
+  <script type="text/javascript">
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+  _paq.push(["setCookieDomain", "*.training.nih-cfde.org"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://nihcfde.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '2']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.src='//cdn.matomo.cloud/nihcfde.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+  </script>
+<!-- End Matomo Code -->
   <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
     <a href="{{ site_url }}" title="{{ config.site_name | e }}" class="md-header-nav__button md-logo" aria-label="{{ config.site_name }}">
       {% include "partials/logo.html" %}


### PR DESCRIPTION
This PR has commits detailing my efforts to isolate why analytics was failing on the training site. The re-deployment inside the header.html seems to be the only viable way for the matomo code to work:

Here is the rendered branch. 

https://training.nih-cfde.org/en/analyticjeremy/?next=https%3A%2F%2Ftraining.nih-cfde.org%2Fen%2Fanalyticjeremy%2F&ticket=ST-1615846716-t8gbEH5IX8TgFeQGxbY9PqrHACb0DEFG

For those with matomo access, the results of visiting the analyticjeremy render can be seen here:
https://nihcfde.matomo.cloud/index.php?module=CoreHome&action=index&idSite=2&period=day&date=yesterday#?idSite=2&period=month&date=2021-03-14&segment=&category=General_Visitors&subcategory=Live_VisitorLog

Currently dev training branch analytics is only recording home page hits which isn't useful.

NOTE: I'm not sure about process on making this happen... if we need to make a new branch and re-deploy please let me know!

## PR Checklist

- [ ] Release label added
- [ ] PR category label added
- [ ] PR mergeable
- [ ] Clean build logs
- [ ] Linked related issues
- [ ] Colorblindness test https://www.toptal.com/designers/colorfilter/

## PR Description
Briefly describe the changes this PR will add/address
**Preview link**
https://training.nih-cfde.org/en/analyticjeremy/?next=https%3A%2F%2Ftraining.nih-cfde.org%2Fen%2Fanalyticjeremy%2F&ticket=ST-1615846716-t8gbEH5IX8TgFeQGxbY9PqrHACb0DEFG

## Review format
Check that all is well and good for deployment. The only change here is the adding of analytics to header.html

## Timeline
ASAP for analytics tracking and reporting purposes related to training events
