### PR TITLE
Add back ticks and quotations

### DIFF
--- a/docs/Website-Style-Guide/2GenTutorialStyle.md
+++ b/docs/Website-Style-Guide/2GenTutorialStyle.md
@@ -64,7 +64,7 @@ Folder names | create a folder called "KF_Data"
 
 &ast;If you refer to this specific file many times, you can put the file name in quotations for the first mention. The "Snakefile" in the Snakemake tutorial is an example where we state that the file is called "Snakefile" but thereafter simply refer to it as Snakefile.
 
-### In-line code formatting with single backticks
+### In-line code formatting with single backticks ` (``) `
 
 Use | Example
 --- | ---


### PR DESCRIPTION
I added these changes to highlight what a backtick looks like. I was aiming to keep the style guide pattern where we show the markdown syntax and show what the rendered version looks like. I noticed for backticks and quotations, we didn't share the explicit syntax.

