### PR TITLE
Update auto_assign_dev.yml

### DIFF
--- a/.github/actions/auto_assign_dev.yml
+++ b/.github/actions/auto_assign_dev.yml
@@ -4,47 +4,10 @@ addReviewers: true
 # Set to true to add assignees to pull requests
 addAssignees: author
 
-# Set to true to add reviewers from different groups to pull requests
-useReviewGroups: true
-
-# A list of reviewers, split into different groups, to be added to pull requests (GitHub user name)
-reviewGroups:
-  groupA:
-    - raynamharris
-    - ACharbonneau
-    - ctb
-
-  groupB:
-    - jeremywalter
-
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - nih-cfde/training
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)
 numberOfReviewers: 0
-
-# A list of assignees, overrides reviewers if set
-# assignees:
-#   - assigneeA
-
-# A number of assignees to add to the pull request
-# Set to 0 to add all of the assignees.
-# Uses numberOfReviewers if unset.
-# numberOfAssignees: 2
-
-# A list of keywords to be skipped the process that add reviewers if pull requests include it
-# skipKeywords:
-#   - wip
-
-# The action will run only if the PR meets the specified filters
-#filterLabels:
-  # Run
-  #include:
-  #  - Oct-2020
-  #  - Dec-2020
-  #  - Mar-2021
-  #  - Jun-2021
-  #  - Sept-2021
-  #  - Dec-2021
-  # Not run
-  #exclude:
-  #  - wip


### PR DESCRIPTION
this PR will just change who gets autoassigned to review PRs to dev (fixed stable earlier with https://github.com/nih-cfde/training-and-engagement/pull/524
